### PR TITLE
Updated Gemfile.lock as net-scp was yanked

### DIFF
--- a/micro/Gemfile.lock
+++ b/micro/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/cloudfoundry/bosh.git
-  revision: 28b7174beac0d5c1ab43938b4cf9526c21dd6796
+  revision: e83c8c5d6b1a6127597b844d451975297d368b06
   specs:
     blobstore_client (1.5.0.pre)
       aws-sdk (~> 1.8.1.1)
@@ -23,6 +23,7 @@ GIT
       ruby-atmos-pure (~> 1.0.5)
       sigar (>= 0.7.2)
       sinatra (~> 1.2.8)
+      sys-filesystem (~> 1.1.0)
       thin (~> 1.5.0)
       uuidtools (~> 2.1.3)
       yajl-ruby (~> 1.1.0)
@@ -40,7 +41,7 @@ GEM
     agent_client (0.1.1)
       httpclient
       yajl-ruby
-    aws-sdk (1.8.1.2)
+    aws-sdk (1.8.1.3)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
@@ -95,15 +96,15 @@ GEM
     libv8 (3.11.8.13)
     log4r (1.1.10)
     mime-types (1.21)
-    multi_json (1.5.1)
+    multi_json (1.6.0)
     multipart-post (1.1.5)
     nats (0.4.28)
       daemons (>= 1.1.5)
       eventmachine (= 0.12.10)
       json_pure (>= 1.7.3)
       thin (>= 1.4.1)
-    net-scp (1.0.6)
-      net-ssh (>= 2.6.5)
+    net-scp (1.0.4)
+      net-ssh (>= 1.99.1)
     net-ssh (2.6.5)
     netaddr (1.5.0)
     nokogiri (1.5.6)
@@ -155,6 +156,8 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     statemachine (2.1.0)
+    sys-filesystem (1.1.0)
+      ffi
     therubyracer (0.11.3)
       libv8 (~> 3.11.8.12)
       ref


### PR DESCRIPTION
This updates Gemfile.lock as net-scp 1.0.6 was yanked. May be consider removing Gemfile.lock from version control.
